### PR TITLE
fix: shoot when there is no ship + tests

### DIFF
--- a/naval_models.rb
+++ b/naval_models.rb
@@ -161,8 +161,9 @@ class Board
       sinked_ship_check(shipId)
       return true
     end
+    @cells[index_i][index_j].gets_shoot
     puts 'El tiro no ha dado en un barco'
-    false
+    return false
   end
 
   # Checks for sinked ship.

--- a/test/naval_test.rb
+++ b/test/naval_test.rb
@@ -72,4 +72,20 @@ class GameTest < Minitest::Test
     assert_equal(true, valid_insert_output_7)
     assert_equal(true, valid_insert_output_8)
   end
+
+  def test_shooting_without_ships
+    #size 10x10 board
+    easy = { 'size' => 10, 'ships' => 5 }
+    game = Game.new(easy) 
+
+    game.board1.shoot_block('A0')
+    assert_equal(true, game.board1.cells[0][0].shot)
+    game.board1.shoot_block('J9')
+    assert_equal(true, game.board1.cells[9][9].shot)
+    game.board1.shoot_block('B3')
+    assert_equal(true, game.board1.cells[1][3].shot)
+    game.board1.shoot_block('E0')
+    assert_equal(true, game.board1.cells[4][0].shot)
+    
+  end 
 end


### PR DESCRIPTION
You can now properly shoot a block within the grid/board and mark it as shoot even when there is not a ship section there